### PR TITLE
Add Prettier support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./index.js"
+  "extends": "./prettier.js"
 }

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
   "dependencies": {
     "babel-eslint": "7.2.3",
     "eslint": "4.5.0",
+    "eslint-config-prettier": "2.6.0",
     "eslint-plugin-flowtype": "2.35.0",
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.3.0"
   },
   "devDependencies": {
     "lodash.difference": "4.4.0",
-    "mocha": "3.0.2"
+    "mocha": "3.0.2",
+    "prettier": "1.7.0"
   }
 }

--- a/prettier.js
+++ b/prettier.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: [
+    require.resolve('./index'),
+    'prettier',
+    'prettier/react',
+  ],
+
+  rules: {},
+};

--- a/prettier.js
+++ b/prettier.js
@@ -1,3 +1,4 @@
+// prettier-ignore
 module.exports = {
   extends: [
     require.resolve('./index'),

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,19 @@ You may optionally configure any specific rules you want to override under the `
 }
 ```
 
+## Prettier Support
+
+If you're using prettier, you can extend from `zapier/prettier` instead to turn-off
+all rules from this config that would conflict with prettier:
+
+```json
+{
+    "extends": [
+        "zapier/prettier"
+    ]
+}
+```
+
 ## Versioning Policy
 
 `eslint-config-zapier` follows a semantic versioning policy along the lines of [ESLint's semver policy](https://github.com/eslint/eslint#semantic-versioning-policy):

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,8 @@ all rules from this config that would conflict with prettier:
 }
 ```
 
+Note that this does **not** enable prettier in the consuming project. It only disables all ESLint rules that would otherwise conflict with prettier.
+
 ## Versioning Policy
 
 `eslint-config-zapier` follows a semantic versioning policy along the lines of [ESLint's semver policy](https://github.com/eslint/eslint#semantic-versioning-policy):

--- a/test/tests.js
+++ b/test/tests.js
@@ -10,42 +10,43 @@ const eslint = require('eslint');
 // setup -----------------------------------------------------------------------
 
 const eslintRules = Object.keys(eslint.linter.defaults().rules);
-const makeLinter = () => (new eslint.CLIEngine({ useEslintrc: false, configFile: './index.js' }));
+const makeLinter = (configFile = './index.js') =>
+  new eslint.CLIEngine({ useEslintrc: false, configFile });
 
 // cases -----------------------------------------------------------------------
 
 exports['eslint-config-zapier'] = {
-
   'all eslint rules are configured': () => {
     const linter = makeLinter();
 
-    const config = linter.getConfigForFile('./index.js');
+    const config = linter.getConfigForFile('foo.js');
 
-    assert.deepEqual(
-      diff(eslintRules, Object.keys(config.rules)),
-      []
-    );
+    assert.deepEqual(diff(eslintRules, Object.keys(config.rules)), []);
   },
 
   'loads react-speficic rules': () => {
     const linter = makeLinter();
-    const config = linter.getConfigForFile('./index.js');
-    const reactRules = Object.keys(config.rules).filter((rule) => rule.startsWith('react'));
+    const config = linter.getConfigForFile('foo.js');
+    const reactRules = Object.keys(config.rules).filter(rule =>
+      rule.startsWith('react')
+    );
 
     assert.ok(reactRules.length > 0);
   },
 
   'loads a11y-related rules': () => {
     const linter = makeLinter();
-    const config = linter.getConfigForFile('./index.js');
-    const a11yRules = Object.keys(config.rules).filter((rule) => rule.startsWith('jsx-a11y'));
+    const config = linter.getConfigForFile('foo.js');
+    const a11yRules = Object.keys(config.rules).filter(rule =>
+      rule.startsWith('jsx-a11y')
+    );
 
     assert.ok(a11yRules.length > 0);
   },
 
   'loads flowtype rules': () => {
     const linter = makeLinter();
-    const config = linter.getConfigForFile('./index.js');
+    const config = linter.getConfigForFile('foo.js');
 
     assert(config.parser, 'babel-eslint');
   },
@@ -56,4 +57,40 @@ exports['eslint-config-zapier'] = {
     assert.doesNotThrow(() => linter.executeOnText(''));
   },
 
+  'exposes a prettier config': () => {
+    const linter = makeLinter('./prettier.js');
+    const config = linter.getConfigForFile('foo.js');
+
+    assert.ok(Object.keys(config.rules).length > 0);
+  },
+
+  'prettier config contains base config': () => {
+    const config = makeLinter('./prettier.js').getConfigForFile('foo.js');
+    const baseConfig = makeLinter('./index.js').getConfigForFile('foo.js');
+
+    assert.deepEqual(
+      diff(Object.keys(baseConfig.rules), Object.keys(config.rules)),
+      []
+    );
+  },
+
+  'prettier config turns a bunch of rules off': () => {
+    const config = makeLinter('./prettier.js').getConfigForFile(
+      './prettier.js'
+    );
+    const baseConfig = makeLinter('./index.js').getConfigForFile('./index.js');
+
+    const getDisabledRules = rules =>
+      Object.keys(rules).reduce((acc, rule) => {
+        if (rules[rule] === 'off') {
+          return acc.concat(rule);
+        }
+        return acc;
+      }, []);
+
+    assert.ok(
+      getDisabledRules(config.rules).length >
+        getDisabledRules(baseConfig.rules).length
+    );
+  },
 };


### PR DESCRIPTION
Add prettier support by way of a `zapier/prettier` config.

If a project is using prettier, it can extend from `zapier/prettier` instead to turn-off all rules from this config that would conflict with prettier:

```json
{
    "extends": [
        "zapier/prettier"
    ]
}
```

Note that this does **not** enable prettier in the consuming project.